### PR TITLE
fix: Correct notification system for admin and customer areas

### DIFF
--- a/CustomerArea.php
+++ b/CustomerArea.php
@@ -112,10 +112,7 @@ include 'php/header.php';
         <!-- My Messages Section -->
         <div class="mt-16">
             <div class="bg-black/20 p-8 rounded-xl backdrop-blur-sm">
-                <div class="flex items-center gap-4 mb-8">
-                    <h3 class="text-4xl font-bold font-serif">I Miei Messaggi</h3>
-                    <span id="message-notification-badge" class="hidden h-6 w-6 flex items-center justify-center rounded-full bg-red-500 text-sm font-bold text-white"></span>
-                </div>
+                <h3 class="text-4xl font-bold mb-8 font-serif">I Miei Messaggi</h3>
                 <div class="space-y-4 max-h-[500px] overflow-y-auto">
                     <?php
                         $user_id = $_SESSION['id'];
@@ -212,30 +209,6 @@ include 'php/header.php';
 </main>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    const notificationBadge = document.getElementById('message-notification-badge');
-
-    function fetchUnreadMessages() {
-        fetch('php/get_unread_messages.php')
-            .then(response => response.json())
-            .then(data => {
-                if (data.status === 'success' && data.unread_count > 0) {
-                    notificationBadge.textContent = data.unread_count;
-                    notificationBadge.classList.remove('hidden');
-                } else {
-                    notificationBadge.classList.add('hidden');
-                }
-            })
-            .catch(error => console.error('Error fetching unread messages:', error));
-    }
-
-    // Fetch immediately on page load
-    fetchUnreadMessages();
-
-    // And then fetch every 30 seconds
-    setInterval(fetchUnreadMessages, 30000);
-});
-
 function deleteMessage(messageId) {
     if (!confirm('Sei sicuro di voler cancellare questo messaggio?')) {
         return;

--- a/php/header.php
+++ b/php/header.php
@@ -53,8 +53,11 @@ if (session_status() == PHP_SESSION_NONE) {
             </nav>
             <div class="hidden items-center gap-4 md:flex">
                 <?php if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true): ?>
-                    <a class="text-white hover:text-[var(--c-gold)] transition-colors text-base font-medium" href="<?php echo $_SESSION['role'] === 'admin' ? 'dasboardAdmin.php' : 'CustomerArea.php'; ?>">
-                        Area Riservata
+                    <a class="relative text-white hover:text-[var(--c-gold)] transition-colors text-base font-medium" href="<?php echo $_SESSION['role'] === 'admin' ? 'dasboardAdmin.php' : 'CustomerArea.php'; ?>">
+                        <span>Area Riservata</span>
+                        <?php if ($_SESSION['role'] !== 'admin'): ?>
+                            <span id="header-message-badge" class="absolute top-0 right-0 -mt-2 -mr-3 hidden h-5 w-5 flex items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white"></span>
+                        <?php endif; ?>
                     </a>
                     <a class="min-w-[120px] cursor-pointer items-center justify-center overflow-hidden rounded-full border border-[var(--c-gold)] bg-transparent h-11 px-6 text-sm font-bold text-white transition-all hover:bg-[var(--c-gold)] hover:text-black flex" href="php/logout.php">
                         <span class="truncate">Logout</span>
@@ -94,3 +97,47 @@ if (session_status() == PHP_SESSION_NONE) {
             </nav>
         </div>
     </header>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Mobile menu toggle
+    const mobileMenuButton = document.getElementById('mobile-menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    mobileMenuButton.addEventListener('click', function() {
+        const isHidden = mobileMenu.classList.contains('hidden');
+        if (isHidden) {
+            mobileMenu.classList.remove('hidden');
+            setTimeout(() => mobileMenu.style.opacity = 1, 10);
+        } else {
+            mobileMenu.style.opacity = 0;
+            setTimeout(() => mobileMenu.classList.add('hidden'), 300);
+        }
+    });
+
+    // --- User Message Notification Logic ---
+    <?php if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true && $_SESSION['role'] !== 'admin'): ?>
+    const notificationBadge = document.getElementById('header-message-badge');
+
+    function fetchUnreadMessages() {
+        if (!notificationBadge) return; // Exit if badge element doesn't exist
+
+        fetch('php/get_unread_messages.php')
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success' && data.unread_count > 0) {
+                    notificationBadge.textContent = data.unread_count;
+                    notificationBadge.classList.remove('hidden');
+                } else {
+                    notificationBadge.classList.add('hidden');
+                }
+            })
+            .catch(error => console.error('Error fetching unread messages:', error));
+    }
+
+    // Fetch immediately on page load
+    fetchUnreadMessages();
+
+    // And then fetch every 30 seconds
+    setInterval(fetchUnreadMessages, 30000);
+    <?php endif; ?>
+});
+</script>


### PR DESCRIPTION
This commit addresses a bug in the previously implemented notification system where notifications were not displaying correctly.

The key fixes include:

1.  **Admin Panel (`dasboardAdmin.php`):**
    -   The global notification badge in the sidebar was insufficient for providing clear, actionable information.
    -   The fix implements a more direct notification system by displaying a badge with the unread message count next to each individual user in the user management list. This allows the administrator to immediately see which conversations have new messages.

2.  **Customer Area (`CustomerArea.php` & `php/header.php`):**
    -   The original implementation marked messages as read as soon as the customer area was loaded, which caused the notification to disappear before the user could see it.
    -   The fix moves the notification logic from `CustomerArea.php` to the global header (`php/header.php`).
    -   A notification badge now appears next to the "Area Riservata" link, visible on all pages to a logged-in customer.
    -   The notification is now correctly cleared only when the user navigates to the message section within `CustomerArea.php`, where the messages are marked as read.