### PR TITLE
feat: Aggiunge la protezione CSRF a tutti i form e gli endpoint

### DIFF
--- a/CustomerArea.php
+++ b/CustomerArea.php
@@ -20,6 +20,7 @@ include 'php/header.php';
         <div class="grid grid-cols-1 md:grid-cols-3 gap-12">
             <div class="md:col-span-1 flex flex-col items-center md:items-start">
                 <form id="avatar-form" class="relative mb-6">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <img id="avatar-image" src="<?php echo htmlspecialchars($profile_image_path ?? 'uploads/avatars/default.png'); ?>" alt="Immagine Profilo" class="bg-center bg-no-repeat aspect-square bg-cover rounded-full w-40 h-40 border-4 border-[var(--c-gold)]">
                     <input type="file" name="profile_image" id="profile_image_input" class="hidden" accept="image/png, image/jpeg, image/gif">
                     <button type="button" id="edit-avatar-button" class="absolute bottom-1 right-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-[var(--c-gold)] text-black transition-transform hover:scale-110">
@@ -55,6 +56,7 @@ include 'php/header.php';
                     <div id="user-data-edit-form" class="hidden mt-6">
                         <div id="update-profile-message" class="text-center mb-4 text-white"></div>
                         <form id="update-profile-form" class="space-y-4">
+                            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                             <div>
                                 <label for="name" class="block text-sm font-medium text-gray-300">Nome</label>
                                 <input type="text" name="name" id="name" value="<?php echo htmlspecialchars($name); ?>" required class="mt-1 block w-full rounded-md border-gray-500 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">
@@ -177,6 +179,7 @@ include 'php/header.php';
                 <h3 class="text-4xl font-bold mb-8 font-serif">Invia un Messaggio all'Amministratore</h3>
                 <div id="user-message-response" class="text-center mb-4 text-white"></div>
                 <form id="user-send-message-form" class="space-y-6 max-w-lg mx-auto">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <div>
                         <label for="user_subject" class="block text-sm font-medium text-white">Oggetto</label>
                         <input type="text" name="subject" id="user_subject" required class="mt-1 block w-full rounded-md border-gray-300 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">
@@ -200,6 +203,7 @@ include 'php/header.php';
                 <h4 class="text-3xl font-bold mb-6 text-[var(--c-gold)] font-serif">Cambia Password</h4>
                 <div id="change-password-message" class="text-center mb-4 text-white"></div>
                 <form id="change-password-form" class="space-y-6 max-w-lg mx-auto">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <div>
                         <label for="current_password" class="block text-sm font-medium text-white">Password Attuale</label>
                         <input type="password" name="current_password" id="current_password" required class="mt-1 block w-full rounded-md border-gray-300 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">
@@ -229,8 +233,10 @@ function deleteMessage(messageId) {
         return;
     }
 
+    const csrfToken = document.querySelector('#user-send-message-form input[name="csrf_token"]').value;
     const formData = new FormData();
     formData.append('message_id', messageId);
+    formData.append('csrf_token', csrfToken);
     const messageDiv = document.getElementById('user-message-response');
 
     fetch('php/delete_message.php', {
@@ -263,10 +269,11 @@ document.getElementById('edit-avatar-button').addEventListener('click', function
 });
 
 document.getElementById('profile_image_input').addEventListener('change', function() {
+    const form = document.getElementById('avatar-form');
     const file = this.files[0];
     if (file) {
-        const formData = new FormData();
-        formData.append('profile_image', file);
+        // Usando new FormData(form), catturiamo automaticamente sia il token CSRF che il file selezionato.
+        const formData = new FormData(form);
         const messageDiv = document.getElementById('avatar-message');
 
         fetch('php/upload_avatar.php', {

--- a/appointment.php
+++ b/appointment.php
@@ -26,6 +26,7 @@ include 'php/header.php';
         <div class="bg-black/20 p-8 rounded-xl backdrop-blur-sm shadow-2xl border border-white/10">
             <div id="message" class="text-center mb-4 text-white"></div>
             <form id="booking-form" class="space-y-6">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                 <div>
                     <label for="name" class="block text-sm font-medium text-white">Nome Completo</label>
                     <input type="text" name="name" id="name" required class="mt-1 block w-full rounded-md border-gray-300 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50" value="<?php echo htmlspecialchars($name); ?>">

--- a/dasboardAdmin.php
+++ b/dasboardAdmin.php
@@ -93,6 +93,7 @@ $result = $stmt->get_result();
                 <h3 class="text-2xl font-bold mb-6 text-white font-serif">Cambia la Tua Password</h3>
                 <div id="change-password-message" class="text-center mb-4 text-white"></div>
                 <form id="change-password-form" class="space-y-6 max-w-lg mx-auto">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <div>
                         <label for="current_password" class="block text-sm font-medium text-white">Password Attuale</label>
                         <input type="password" name="current_password" id="current_password" required class="mt-1 block w-full rounded-md border-gray-500 bg-[#111722] text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">

--- a/dasboardAdminComunicazioni.php
+++ b/dasboardAdminComunicazioni.php
@@ -101,6 +101,7 @@ $messages_result = $messages_stmt->get_result();
                     <h3 class="text-xl font-bold text-white mb-4 font-serif">Invia Nuovo Messaggio</h3>
                     <div id="message-response" class="text-center mb-4 text-white"></div>
                     <form id="send-message-form" class="space-y-4">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                         <input type="hidden" name="receiver_id" value="<?php echo $receiver_id; ?>">
                         <div>
                             <label for="subject" class="block text-sm font-medium text-gray-300">Oggetto</label>
@@ -127,8 +128,10 @@ function deleteMessage(messageId) {
         return;
     }
 
+    const csrfToken = document.querySelector('#send-message-form input[name="csrf_token"]').value;
     const formData = new FormData();
     formData.append('message_id', messageId);
+    formData.append('csrf_token', csrfToken);
     const messageDiv = document.getElementById('message-response');
 
     fetch('php/delete_message.php', {

--- a/dasboardAdminGestioneSconti.php
+++ b/dasboardAdminGestioneSconti.php
@@ -48,6 +48,7 @@ $discounts_result = $conn->query("SELECT d.*, u.name as user_name FROM discounts
                     <h3 class="text-xl font-bold text-white mb-4 font-serif">Crea Nuovo Sconto</h3>
                     <div id="discount-message" class="text-center mb-4 text-white"></div>
                     <form id="create-discount-form" class="space-y-4">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                         <div>
                             <label for="user_id" class="block text-sm font-medium text-gray-300">Seleziona Utente</label>
                             <select name="user_id" id="user_id" required class="mt-1 block w-full rounded-md border-gray-500 bg-[#111722] text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">

--- a/dasboardAdmingestionePrenotazio.php
+++ b/dasboardAdmingestionePrenotazio.php
@@ -104,6 +104,7 @@ $result = $conn->query("SELECT * FROM bookings ORDER BY id DESC");
                 <h3 class="text-2xl font-bold mb-6 text-white font-serif">Aggiungi Nuova Prenotazione</h3>
                 <div id="add-booking-message" class="text-center mb-4 text-white"></div>
                 <form id="add-booking-form" class="space-y-6 max-w-2xl mx-auto">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
                             <label for="name" class="block text-sm font-medium text-white">Nome Cliente</label>
@@ -146,9 +147,11 @@ function updateStatus(bookingId, newStatus) {
         return;
     }
 
+    const csrfToken = document.querySelector('#add-booking-form input[name="csrf_token"]').value;
     const formData = new FormData();
     formData.append('booking_id', bookingId);
     formData.append('new_status', newStatus);
+    formData.append('csrf_token', csrfToken);
 
     fetch('php/update_booking_status.php', {
         method: 'POST',

--- a/login.php
+++ b/login.php
@@ -38,6 +38,7 @@
             <h3 class="font-serif text-2xl font-bold text-center text-white mb-6">Accedi al tuo account</h3>
             <div id="message" class="text-center mb-4 text-white"></div>
             <form id="login-form" class="space-y-6">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                 <div>
                     <label for="email" class="block text-sm font-medium text-white">Email</label>
                     <input type="email" name="email" id="email" required class="mt-1 block w-full rounded-md border-gray-300 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">

--- a/php/admin_create_booking.php
+++ b/php/admin_create_booking.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in and is an admin

--- a/php/change_password.php
+++ b/php/change_password.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in

--- a/php/config.php
+++ b/php/config.php
@@ -33,4 +33,8 @@ try {
     http_response_code(500);
     die("Errore interno del server. Si prega di riprovare più tardi.");
 }
+
+// Includi il gestore CSRF e genera un token per la sessione corrente.
+require_once 'csrf_handler.php';
+generate_csrf_token();
 ?>

--- a/php/create_booking.php
+++ b/php/create_booking.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/php/create_discount.php
+++ b/php/create_discount.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in and is an admin

--- a/php/csrf_handler.php
+++ b/php/csrf_handler.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Gestore per la protezione da Cross-Site Request Forgery (CSRF).
+ */
+
+/**
+ * Genera un token CSRF se non ne esiste già uno nella sessione.
+ *
+ * @return string Il token CSRF.
+ */
+function generate_csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+/**
+ * Verifica il token CSRF inviato tramite un form POST.
+ *
+ * Termina l'esecuzione dello script se il token non è valido o mancante,
+ * rispondendo con un JSON di errore.
+ */
+function verify_csrf_token() {
+    // La protezione CSRF si applica solo alle richieste che modificano lo stato, tipicamente POST.
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        // Per altre richieste, non facciamo nulla.
+        return;
+    }
+
+    if (!isset($_POST['csrf_token']) || !isset($_SESSION['csrf_token'])) {
+        http_response_code(403);
+        echo json_encode(['status' => 'error', 'message' => 'Token CSRF mancante. Richiesta bloccata.']);
+        exit;
+    }
+
+    if (!hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        http_response_code(403);
+        echo json_encode(['status' => 'error', 'message' => 'Token CSRF non valido. Richiesta bloccata.']);
+        exit;
+    }
+
+    // Opzionale ma consigliato: invalida il token dopo l'uso per prevenire replay attacks.
+    // unset($_SESSION['csrf_token']);
+}
+?>

--- a/php/delete_message.php
+++ b/php/delete_message.php
@@ -1,6 +1,9 @@
 <?php
 include 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 header('Content-Type: application/json');
 
 // Check if the user is logged in

--- a/php/login.php
+++ b/php/login.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/php/register.php
+++ b/php/register.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/php/send_message.php
+++ b/php/send_message.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in and is an admin

--- a/php/update_booking_status.php
+++ b/php/update_booking_status.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in and is an admin

--- a/php/update_user_profile.php
+++ b/php/update_user_profile.php
@@ -1,6 +1,9 @@
 <?php
 include 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 header('Content-Type: application/json');
 
 // Check if the user is logged in

--- a/php/upload_avatar.php
+++ b/php/upload_avatar.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in

--- a/php/user_send_message.php
+++ b/php/user_send_message.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'config.php';
 
+// Verifica il token CSRF prima di procedere
+verify_csrf_token();
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 // Ensure user is logged in

--- a/register.php
+++ b/register.php
@@ -38,6 +38,7 @@
             <h3 class="font-serif text-2xl font-bold text-center text-white mb-6">Crea un nuovo account</h3>
             <div id="message" class="text-center mb-4 text-white"></div>
             <form id="register-form" class="space-y-6">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                 <div>
                     <label for="name" class="block text-sm font-medium text-white">Nome</label>
                     <input type="text" name="name" id="name" required class="mt-1 block w-full rounded-md border-gray-300 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">


### PR DESCRIPTION
- Crea un nuovo `php/csrf_handler.php` con funzioni per generare e verificare i token CSRF utilizzando `hash_equals` per prevenire attacchi di timing.
- Integra la generazione del token in `php/config.php` per renderlo disponibile a livello globale nella sessione.
- Aggiunge un campo nascosto con il token CSRF a tutti i form HTML nelle pagine:
  - `login.php`
  - `register.php`
  - `appointment.php`
  - `CustomerArea.php` (multipli form)
  - `dasboardAdmin.php` (e pagine correlate)
- Aggiorna le chiamate JavaScript `fetch` per includere il token CSRF nelle richieste dinamiche (es. cancellazione messaggi, aggiornamento stato prenotazioni).
- Implementa la verifica del token CSRF all'inizio di tutti gli script PHP che gestiscono richieste POST, bloccando le richieste non valide.