### PR TITLE
feat: Aggiunge CSP e altri header di sicurezza

### DIFF
--- a/CustomerArea.php
+++ b/CustomerArea.php
@@ -227,7 +227,7 @@ include 'php/header.php';
     </div>
 </main>
 
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 function deleteMessage(messageId) {
     if (!confirm('Sei sicuro di voler cancellare questo messaggio?')) {
         return;

--- a/appointment.php
+++ b/appointment.php
@@ -69,7 +69,7 @@ include 'php/header.php';
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <!-- Italian locale for flatpickr (must be after the main script) -->
 <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/it.js"></script>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 document.addEventListener('DOMContentLoaded', function() {
     // Fetch booked dates and initialize the calendar
     fetch('php/get_booked_dates.php')

--- a/dasboardAdmin.php
+++ b/dasboardAdmin.php
@@ -1,4 +1,6 @@
 <?php
+// Includi per primo gli header di sicurezza per assicurarti che vengano inviati prima di ogni altro output.
+require_once 'php/security_headers.php';
 include 'php/config.php';
 include 'php/admin_security.php';
 
@@ -25,7 +27,7 @@ $result = $stmt->get_result();
     <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="css/style.css" rel="stylesheet"/>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -116,7 +118,7 @@ $result = $stmt->get_result();
         </main>
     </div>
 </div>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 document.getElementById('change-password-form').addEventListener('submit', function(e) {
     e.preventDefault();
     const form = e.target;

--- a/dasboardAdminComunicazioni.php
+++ b/dasboardAdminComunicazioni.php
@@ -1,4 +1,6 @@
 <?php
+// Includi per primo gli header di sicurezza per assicurarti che vengano inviati prima di ogni altro output.
+require_once 'php/security_headers.php';
 include 'php/config.php';
 include 'php/admin_security.php';
 
@@ -52,7 +54,7 @@ $messages_result = $messages_stmt->get_result();
     <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="css/style.css" rel="stylesheet"/>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -122,7 +124,7 @@ $messages_result = $messages_stmt->get_result();
         </main>
     </div>
 </div>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 function deleteMessage(messageId) {
     if (!confirm('Sei sicuro di voler cancellare questo messaggio?')) {
         return;

--- a/dasboardAdminGestioneSconti.php
+++ b/dasboardAdminGestioneSconti.php
@@ -1,4 +1,6 @@
 <?php
+// Includi per primo gli header di sicurezza per assicurarti che vengano inviati prima di ogni altro output.
+require_once 'php/security_headers.php';
 include 'php/config.php';
 include 'php/admin_security.php';
 
@@ -20,7 +22,7 @@ $discounts_result = $conn->query("SELECT d.*, u.name as user_name FROM discounts
     <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="css/style.css" rel="stylesheet"/>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -117,7 +119,7 @@ $discounts_result = $conn->query("SELECT d.*, u.name as user_name FROM discounts
         </main>
     </div>
 </div>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 document.getElementById('create-discount-form').addEventListener('submit', function(e) {
     e.preventDefault();
     const form = e.target;

--- a/dasboardAdmingestionePrenotazio.php
+++ b/dasboardAdmingestionePrenotazio.php
@@ -1,4 +1,6 @@
 <?php
+// Includi per primo gli header di sicurezza per assicurarti che vengano inviati prima di ogni altro output.
+require_once 'php/security_headers.php';
 include 'php/config.php';
 include 'php/admin_security.php';
 
@@ -19,7 +21,7 @@ $result = $conn->query("SELECT * FROM bookings ORDER BY id DESC");
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="css/style.css" rel="stylesheet"/>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -140,7 +142,7 @@ $result = $conn->query("SELECT * FROM bookings ORDER BY id DESC");
         </main>
     </div>
 </div>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 function updateStatus(bookingId, newStatus) {
     const messageDiv = document.getElementById('booking-message');
     if (!confirm(`Sei sicuro di voler impostare lo stato su '${newStatus}' per questa prenotazione?`)) {
@@ -218,7 +220,7 @@ function updateStatus(bookingId, newStatus) {
         </main>
     </div>
 </div>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 document.getElementById('add-booking-form').addEventListener('submit', function(e) {
     e.preventDefault();
     const form = e.target;
@@ -251,7 +253,7 @@ document.getElementById('add-booking-form').addEventListener('submit', function(
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <!-- Italian locale for flatpickr (must be after the main script) -->
 <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/it.js"></script>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 document.addEventListener('DOMContentLoaded', function() {
     // Fetch booked dates and initialize the calendar for the admin form
     fetch('php/get_booked_dates.php')

--- a/login.php
+++ b/login.php
@@ -1,3 +1,4 @@
+<?php require_once 'php/security_headers.php'; ?>
 <!DOCTYPE html>
 <html lang="it">
 <head>
@@ -8,7 +9,7 @@
     <title>Login - Villa Paradiso</title>
     <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -59,7 +60,7 @@
         </div>
     </div>
 
-    <script>
+    <script nonce="<?php echo CSP_NONCE; ?>">
         document.getElementById('login-form').addEventListener('submit', function(e) {
             e.preventDefault();
             const form = e.target;

--- a/php/header.php
+++ b/php/header.php
@@ -2,6 +2,8 @@
 if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }
+// Includi gli header di sicurezza (CSP, etc.) prima di qualsiasi output HTML
+require_once 'security_headers.php';
 ?>
 <!DOCTYPE html>
 <html lang="it">
@@ -15,7 +17,7 @@ if (session_status() == PHP_SESSION_NONE) {
     <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="css/style.css" rel="stylesheet"/>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -94,7 +96,7 @@ if (session_status() == PHP_SESSION_NONE) {
             </nav>
         </div>
     </header>
-<script>
+<script nonce="<?php echo CSP_NONCE; ?>">
 document.addEventListener('DOMContentLoaded', function() {
     // Mobile menu toggle
     const mobileMenuButton = document.getElementById('mobile-menu-button');

--- a/php/security_headers.php
+++ b/php/security_headers.php
@@ -1,0 +1,36 @@
+<?php
+// Genera un nonce crittograficamente sicuro
+$nonce = bin2hex(random_bytes(16));
+
+// Definisci il nonce come costante per poterlo usare facilmente nell'HTML
+if (!defined('CSP_NONCE')) {
+    define('CSP_NONCE', $nonce);
+}
+
+// Definisci la Content Security Policy (CSP)
+// Questa policy è restrittiva e permette solo le risorse specificate.
+$csp = "default-src 'self';"; // Di default, permetti solo dal nostro dominio
+$csp .= " script-src 'self' 'nonce-" . CSP_NONCE . "' https://cdn.tailwindcss.com;"; // Script: solo dal nostro dominio, con il nonce, o da tailwind
+$csp .= " style-src 'self' 'nonce-" . CSP_NONCE . "' https://fonts.googleapis.com;"; // Stili: solo dal nostro dominio, con il nonce, o da google fonts
+$csp .= " font-src 'self' https://fonts.gstatic.com;"; // Font: solo dal nostro dominio o da gstatic
+$csp .= " img-src 'self' data: https://lh3.googleusercontent.com;"; // Immagini: solo dal nostro dominio, data URIs (per favicon), o da google user content (per sfondi login)
+$csp .= " connect-src 'self';"; // Connessioni (fetch/AJAX): solo al nostro dominio
+$csp .= " frame-ancestors 'none';"; // Impedisce al sito di essere inserito in un iframe (protezione da clickjacking)
+$csp .= " form-action 'self';"; // I form possono inviare dati solo al nostro dominio
+$csp .= " base-uri 'self';"; // Limita gli URL che possono essere usati nel tag <base>
+$csp .= " object-src 'none';"; // Non permettere l'inclusione di plugin come Flash
+
+// Invia l'header CSP
+header("Content-Security-Policy: " . $csp);
+
+// Altri header di sicurezza raccomandati
+// Impedisce al browser di interpretare i file in modo diverso dal tipo di contenuto dichiarato
+header("X-Content-Type-Options: nosniff");
+
+// Protezione aggiuntiva contro il clickjacking per browser più vecchi
+header("X-Frame-Options: DENY");
+
+// Forza l'uso di HTTPS per tutte le future connessioni (se il sito è su HTTPS)
+// NOTA: Decommentare solo in produzione su un sito con certificato SSL valido.
+// header("Strict-Transport-Security: max-age=31536000; includeSubDomains");
+?>

--- a/register.php
+++ b/register.php
@@ -1,3 +1,4 @@
+<?php require_once 'php/security_headers.php'; ?>
 <!DOCTYPE html>
 <html lang="it">
 <head>
@@ -8,7 +9,7 @@
     <title>Registrazione - Villa Paradiso</title>
     <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <style type="text/tailwindcss">
+    <style type="text/tailwindcss" nonce="<?php echo CSP_NONCE; ?>">
         :root {
             --c-gold: #c5a87b;
             --c-gold-bright: #e6c589;
@@ -67,7 +68,7 @@
         </div>
     </div>
 
-    <script>
+    <script nonce="<?php echo CSP_NONCE; ?>">
         document.getElementById('register-form').addEventListener('submit', function(e) {
             e.preventDefault();
             const form = e.target;


### PR DESCRIPTION
- Crea un nuovo file `php/security_headers.php` per centralizzare la gestione degli header di sicurezza.
- Definisce una Content Security Policy (CSP) restrittiva che permette risorse solo da fonti fidate e utilizza un "nonce" per gli script/stili inline.
- Aggiunge header di sicurezza come `X-Content-Type-Options` e `X-Frame-Options` per mitigare attacchi di MIME-sniffing e clickjacking.
- Integra `security_headers.php` in tutte le pagine dell'applicazione per una protezione globale.
- Applica l'attributo `nonce` a tutti i tag `<script>` e `<style>` inline per renderli conformi alla CSP.