### PR TITLE
feat: Aggiorna l'hashing delle password a Argon2id

### DIFF
--- a/php/change_password.php
+++ b/php/change_password.php
@@ -38,8 +38,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             // Verify the current password
             if (password_verify($current_password, $hashed_password)) {
-                // Hash the new password
-                $new_hashed_password = password_hash($new_password, PASSWORD_DEFAULT);
+                // Hash the new password using the most secure algorithm
+                $new_hashed_password = password_hash($new_password, PASSWORD_ARGON2ID);
 
                 // Update the password in the database
                 $update_stmt = $conn->prepare("UPDATE users SET password = ? WHERE id = ?");

--- a/php/login.php
+++ b/php/login.php
@@ -33,6 +33,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $_SESSION['name'] = $name;
                     $_SESSION['role'] = $role;
 
+                    // Controlla se la password necessita di essere ri-hashata con l'algoritmo più recente
+                    if (password_needs_rehash($hashed_password, PASSWORD_ARGON2ID)) {
+                        $new_hash = password_hash($password, PASSWORD_ARGON2ID);
+                        $rehash_stmt = $conn->prepare("UPDATE users SET password = ? WHERE id = ?");
+                        $rehash_stmt->bind_param("si", $new_hash, $id);
+                        $rehash_stmt->execute();
+                        $rehash_stmt->close();
+                    }
+
                     $response['status'] = 'success';
                     $response['message'] = 'Login successful!';
                     $response['role'] = $role; // Send role to redirect accordingly

--- a/php/register.php
+++ b/php/register.php
@@ -27,8 +27,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($stmt->num_rows > 0) {
                 $response['message'] = 'Email already registered.';
             } else {
-                // Hash the password
-                $hashed_password = password_hash($password, PASSWORD_DEFAULT);
+                // Hash the password using the most secure algorithm currently available
+                $hashed_password = password_hash($password, PASSWORD_ARGON2ID);
 
                 // Insert the new user
                 $stmt = $conn->prepare("INSERT INTO users (name, email, password, phone) VALUES (?, ?, ?, ?)");


### PR DESCRIPTION
- Sostituisce `PASSWORD_DEFAULT` con `PASSWORD_ARGON2ID` in `php/register.php` e `php/change_password.php`, assicurando che tutte le nuove password siano hashate con l'algoritmo più robusto.
- Implementa una logica di re-hashing automatico in `php/login.php`.
- Utilizza `password_needs_rehash()` per identificare le password che utilizzano un algoritmo obsoleto dopo un login riuscito.
- Se una password necessita di essere aggiornata, viene ri-hashata con `PASSWORD_ARGON2ID` e il nuovo hash viene salvato nel database.
- Questo garantisce una migrazione sicura e trasparente per tutti gli utenti esistenti nel tempo.