### PR TITLE
feat: Implement password reset functionality

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -7,6 +7,8 @@ CREATE TABLE `users` (
   `phone` varchar(20) DEFAULT NULL,
   `profile_image_path` varchar(255) DEFAULT 'uploads/avatars/default.png',
   `role` enum('user','admin') NOT NULL DEFAULT 'user',
+  `password_reset_token` varchar(255) DEFAULT NULL,
+  `password_reset_expires` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/forgot_password.php
+++ b/forgot_password.php
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Dimenticata - Villa Paradiso</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <?php include 'php/header.php'; ?>
+
+    <main class="form-container">
+        <h2>Password Dimenticata</h2>
+        <p>Inserisci il tuo indirizzo email per ricevere un link per reimpostare la tua password.</p>
+        <form id="forgot-password-form" action="php/request_password_reset.php" method="POST">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+            <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required>
+            </div>
+            <button type="submit" class="btn">Invia link di reset</button>
+        </form>
+        <div id="form-messages" class="form-messages"></div>
+    </main>
+
+    <?php include 'php/footer.php'; ?>
+
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -48,6 +48,9 @@
                     <label for="password" class="block text-sm font-medium text-white">Password</label>
                     <input type="password" name="password" id="password" required class="mt-1 block w-full rounded-md border-gray-300 bg-white/20 text-white shadow-sm focus:border-[var(--c-gold)] focus:ring focus:ring-[var(--c-gold)] focus:ring-opacity-50">
                 </div>
+                <div class="text-right">
+                    <a href="forgot_password.php" class="text-sm text-[var(--c-gold-bright)] hover:text-[var(--c-gold)]">Password dimenticata?</a>
+                </div>
                 <div>
                     <button type="submit" class="w-full flex justify-center py-2 px-4 border border-transparent rounded-full shadow-sm text-sm font-bold text-black bg-[var(--c-gold-bright)] hover:bg-[var(--c-gold)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--c-gold)] transition-all">
                         Accedi

--- a/php/email_handler.php
+++ b/php/email_handler.php
@@ -54,4 +54,33 @@ function send_booking_emails($customer_email, $customer_name, $check_in, $check_
 
     mail(ADMIN_EMAIL, $admin_subject, $admin_message, $admin_headers);
 }
+
+function send_password_reset_email($user_email, $reset_link) {
+    $subject = 'Richiesta di Reset Password - Villa Paradiso';
+    $message = "
+        <html>
+        <head>
+            <title>Reset della tua Password</title>
+        </head>
+        <body>
+            <p>Ciao,</p>
+            <p>Abbiamo ricevuto una richiesta di reset della password per il tuo account.</p>
+            <p>Clicca sul link qui sotto per scegliere una nuova password. Il link scadrà tra un'ora.</p>
+            <p><a href='" . htmlspecialchars($reset_link) . "'>Reimposta la tua password</a></p>
+            <p>Se non hai richiesto tu il reset, puoi tranquillamente ignorare questa email.</p>
+            <p>Grazie,<br>Il team di Villa Paradiso</p>
+        </body>
+        </html>
+    ";
+
+    $headers = "MIME-Version: 1.0" . "\r\n";
+    $headers .= "Content-type:text/html;charset=UTF-8" . "\r\n";
+    $headers .= "From: no-reply@villaparadiso.com" . "\r\n"; // Usa un indirizzo no-reply
+
+    // Invia l'email
+    if (!mail($user_email, $subject, $message, $headers)) {
+        // Lancia un'eccezione se l'invio fallisce, che può essere catturata nel chiamante
+        throw new Exception("La funzione mail() ha restituito false.");
+    }
+}
 ?>

--- a/php/request_password_reset.php
+++ b/php/request_password_reset.php
@@ -1,0 +1,79 @@
+<?php
+require_once 'config.php';
+require_once 'email_handler.php';
+require_once 'security_logger.php';
+
+// Verify the CSRF token
+verify_csrf_token();
+
+$response = ['status' => 'error', 'message' => 'Si è verificato un errore sconosciuto.'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['email'])) {
+        $email = trim($_POST['email']);
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $response['message'] = 'Formato email non valido.';
+        } else {
+            // Check if the user exists
+            $stmt = $conn->prepare("SELECT id FROM users WHERE email = ?");
+            $stmt->bind_param("s", $email);
+            $stmt->execute();
+            $stmt->store_result();
+
+            if ($stmt->num_rows > 0) {
+                // User exists, generate a reset token
+                $token = bin2hex(random_bytes(32)); // Generate a secure random token
+                $token_hash = hash('sha256', $token); // Hash the token for storage
+
+                // Set token expiration (e.g., 1 hour from now)
+                $expires = new DateTime('now');
+                $expires->add(new DateInterval('PT1H'));
+                $expires_str = $expires->format('Y-m-d H:i:s');
+
+                // Store the hashed token and its expiration date in the database
+                $update_stmt = $conn->prepare("UPDATE users SET password_reset_token = ?, password_reset_expires = ? WHERE email = ?");
+                $update_stmt->bind_param("sss", $token_hash, $expires_str, $email);
+
+                if ($update_stmt->execute()) {
+                    // Send the password reset email
+                    // IMPORTANT: In a real production environment, ensure the domain is not hardcoded.
+                    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http";
+                    $reset_link = $protocol . "://" . $_SERVER['HTTP_HOST'] . "/reset_password.php?token=" . $token;
+
+                    try {
+                        send_password_reset_email($email, $reset_link);
+                        log_security_event("Richiesta di reset password inviata per l'email: " . $email);
+                        // Always show a generic success message to prevent user enumeration
+                        $response['status'] = 'success';
+                        $response['message'] = 'Se l\'indirizzo email è nel nostro sistema, riceverai un link per il reset della password.';
+                    } catch (Exception $e) {
+                        log_security_event("Errore durante l'invio dell'email di reset password per: " . $email . " - Errore: " . $e->getMessage());
+                        $response['message'] = 'Impossibile inviare l\'email di reset. Riprova più tardi.';
+                    }
+                } else {
+                    log_security_event("Errore DB durante l'aggiornamento del token di reset per l'email: " . $email);
+                    $response['message'] = 'Si è verificato un errore nel database.';
+                }
+                $update_stmt->close();
+
+            } else {
+                // Email not found, but we give a generic message to prevent user enumeration
+                log_security_event("Tentativo di reset password per email non registrata: " . $email);
+                $response['status'] = 'success'; // Still return success to prevent email snooping
+                $response['message'] = 'Se l\'indirizzo email è nel nostro sistema, riceverai un link per il reset della password.';
+            }
+            $stmt->close();
+        }
+    } else {
+        $response['message'] = 'Campo email mancante.';
+    }
+} else {
+    $response['message'] = 'Metodo di richiesta non valido.';
+}
+
+$conn->close();
+
+header('Content-Type: application/json');
+echo json_encode($response);
+?>

--- a/php/update_password.php
+++ b/php/update_password.php
@@ -1,0 +1,84 @@
+<?php
+require_once 'config.php';
+require_once 'security_logger.php';
+
+// Verify the CSRF token
+verify_csrf_token();
+
+$response = ['status' => 'error', 'message' => 'Si è verificato un errore sconosciuto.'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['token'], $_POST['new_password'], $_POST['confirm_password'])) {
+        $token = $_POST['token'];
+        $new_password = $_POST['new_password'];
+        $confirm_password = $_POST['confirm_password'];
+
+        // --- Password Policy Validation ---
+        if ($new_password !== $confirm_password) {
+            $response['message'] = 'Le password non coincidono.';
+        } elseif (strlen($new_password) < 12) {
+            $response['message'] = 'La nuova password deve essere lunga almeno 12 caratteri.';
+        } elseif (!preg_match('/[A-Z]/', $new_password)) {
+            $response['message'] = 'La nuova password deve contenere almeno una lettera maiuscola.';
+        } elseif (!preg_match('/[a-z]/', $new_password)) {
+            $response['message'] = 'La nuova password deve contenere almeno una lettera minuscola.';
+        } elseif (!preg_match('/[0-9]/', $new_password)) {
+            $response['message'] = 'La nuova password deve contenere almeno un numero.';
+        } elseif (!preg_match('/[\W_]/', $new_password)) {
+            $response['message'] = 'La nuova password deve contenere almeno un carattere speciale.';
+        } else {
+            // --- Token Validation ---
+            $token_hash = hash('sha256', $token);
+
+            // Find the user by the hashed token and check if the token is still valid
+            $stmt = $conn->prepare("SELECT id, password_reset_expires FROM users WHERE password_reset_token = ?");
+            $stmt->bind_param("s", $token_hash);
+            $stmt->execute();
+            $stmt->store_result();
+
+            if ($stmt->num_rows > 0) {
+                $stmt->bind_result($user_id, $expires_str);
+                $stmt->fetch();
+
+                $now = new DateTime();
+                $expires = new DateTime($expires_str);
+
+                if ($now > $expires) {
+                    log_security_event("Tentativo di reset password con token scaduto per l'utente ID: " . $user_id);
+                    $response['message'] = 'Il link di reset è scaduto. Richiedine uno nuovo.';
+                } else {
+                    // Token is valid and not expired, proceed with password update
+                    $hashed_password = password_hash($new_password, PASSWORD_ARGON2ID);
+
+                    // Update password and clear the reset token fields
+                    $update_stmt = $conn->prepare("UPDATE users SET password = ?, password_reset_token = NULL, password_reset_expires = NULL WHERE id = ?");
+                    $update_stmt->bind_param("si", $hashed_password, $user_id);
+
+                    if ($update_stmt->execute()) {
+                        log_security_event("Password reimpostata con successo per l'utente ID: " . $user_id);
+                        $response['status'] = 'success';
+                        $response['message'] = 'Password aggiornata con successo! Ora puoi effettuare il login con la nuova password.';
+                    } else {
+                        log_security_event("Errore DB durante l'aggiornamento della password per l'utente ID: " . $user_id);
+                        $response['message'] = 'Impossibile aggiornare la password. Riprova.';
+                    }
+                    $update_stmt->close();
+                }
+            } else {
+                log_security_event("Tentativo di reset password con token non valido o già utilizzato.");
+                $response['message'] = 'Token di reset non valido. Potrebbe essere già stato utilizzato o non essere corretto.';
+            }
+            $stmt->close();
+        }
+    } else {
+        $response['message'] = 'Campi mancanti.';
+    }
+} else {
+    $response['message'] = 'Metodo di richiesta non valido.';
+}
+
+$conn->close();
+
+header('Content-Type: application/json');
+echo json_encode($response);
+?>

--- a/reset_password.php
+++ b/reset_password.php
@@ -1,0 +1,45 @@
+<?php
+// We need to start the session to get the CSRF token, but we do it after checking the token
+// to avoid creating unnecessary sessions.
+$token = isset($_GET['token']) ? $_GET['token'] : '';
+if (empty($token)) {
+    die("Token non valido o mancante.");
+}
+require_once 'php/config.php'; // This will start the session and generate a CSRF token
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reimposta Password - Villa Paradiso</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <?php include 'php/header.php'; ?>
+
+    <main class="form-container">
+        <h2>Reimposta la tua Password</h2>
+        <form id="reset-password-form" action="php/update_password.php" method="POST">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+            <input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
+
+            <div class="form-group">
+                <label for="new_password">Nuova Password</label>
+                <input type="password" id="new_password" name="new_password" required>
+            </div>
+            <div class="form-group">
+                <label for="confirm_password">Conferma Nuova Password</label>
+                <input type="password" id="confirm_password" name="confirm_password" required>
+            </div>
+
+            <button type="submit" class="btn">Reimposta Password</button>
+        </form>
+        <div id="form-messages" class="form-messages"></div>
+    </main>
+
+    <?php include 'php/footer.php'; ?>
+
+    <script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a complete and secure password reset feature. Users who have forgotten their password can now request a reset link to be sent to their email address.

The implementation includes:
- Database Schema Update: The `users` table is modified to include `password_reset_token` and `password_reset_expires` columns.
- Frontend Pages: New pages `forgot_password.php` and `reset_password.php` have been created to provide the user interface for the flow.
- Backend Logic: New scripts `php/request_password_reset.php` and `php/update_password.php` handle the core logic, including secure token generation, validation, and password updating.
- Email Handling: A new function `send_password_reset_email` has been added to `php/email_handler.php` to send the reset link.
- Security: The feature is built with security in mind, incorporating CSRF token validation, hashed tokens in the database, token expiration, and protection against user enumeration attacks.
- UI Integration: A "Password dimenticata?" (Forgot password?) link has been added to the login page for easy user access.